### PR TITLE
Implemented moving group to a step

### DIFF
--- a/src/app/teacher/manage-groups.module.ts
+++ b/src/app/teacher/manage-groups.module.ts
@@ -8,6 +8,7 @@ import { EditGroupNameComponent } from '../../assets/wise5/classroomMonitor/clas
 import { ListGroupsComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/list-groups/list-groups.component';
 import { ManageGroupComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/manage-group/manage-group.component';
 import { ManageGroupsComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/manage-groups/manage-groups.component';
+import { MoveGroupToNodeComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-to-node/move-group-to-node.component';
 import { AngularJSModule } from '../common-hybrid-angular.module';
 
 @NgModule({
@@ -20,7 +21,8 @@ import { AngularJSModule } from '../common-hybrid-angular.module';
     EditGroupNameComponent,
     ListGroupsComponent,
     ManageGroupComponent,
-    ManageGroupsComponent
+    ManageGroupsComponent,
+    MoveGroupToNodeComponent
   ],
   imports: [AngularJSModule]
 })

--- a/src/assets/score/teachingassistant/src/app/core/components/go-to-node-select/go-to-node-select.component.html
+++ b/src/assets/score/teachingassistant/src/app/core/components/go-to-node-select/go-to-node-select.component.html
@@ -3,6 +3,7 @@
         <th mat-header-cell *matHeaderCellDef>
             <h2 *ngIf="workgroup != null">Choose which step to send Workgroup {{workgroup.name}} to</h2>
             <h2 *ngIf="period != null">Choose which step to send Period {{period.name}} to</h2>
+            <h2 *ngIf="group != null">Choose which step to send Group {{group.name}} to</h2>
         </th>
         <td mat-cell *matCellDef="let nodeInOrder"><button mat-button (click)="sendToNode(nodeInOrder.node)">{{nodeInOrder.stepNumber}} {{nodeInOrder.node.title}}</button></td>
       </ng-container>

--- a/src/assets/score/teachingassistant/src/app/core/components/go-to-node-select/go-to-node-select.component.ts
+++ b/src/assets/score/teachingassistant/src/app/core/components/go-to-node-select/go-to-node-select.component.ts
@@ -3,34 +3,42 @@ import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { TeacherWebSocketService } from '../../../../../../../../assets/wise5/services/teacherWebSocketService';
 import { Run } from '../../../../../../../../app/domain/run';
 import { Workgroup } from '../../../../../../../../app/domain/workgroup';
+import { Tag } from '../../../../../../../../app/domain/tag';
+import { ProjectService } from '../../../../../../../wise5/services/projectService';
+import { Project } from '../../../../../../../../app/domain/project';
 
 @Component({
     selector: 'app-go-to-node-select',
     templateUrl: './go-to-node-select.component.html',
     styleUrls: ['./go-to-node-select.component.scss'],
 })
-export class GoToNodeSelectComponent implements OnInit {
+export class GoToNodeSelectComponent {
+    group: Tag;
+    period: any;
     run: Run;
     stepNodes: any[] = [];
-    period: any;
     workgroup: Workgroup;
     displayedColumns: string[] = ['stepName'];
 
     constructor(
         @Inject(MAT_DIALOG_DATA) public data: any,
+        private projectService: ProjectService,
         private websocketService: TeacherWebSocketService,
     ) {
-        this.run = data.run;
-        for (const nodeInOrder of this.run.project.idToOrder.nodes) {
+        const project = new Project();
+        project.setContent(this.projectService.project);
+        for (const nodeInOrder of project.idToOrder.nodes) {
             if (nodeInOrder.node.type !== 'group') {
+                nodeInOrder.stepNumber = this.projectService.getNodePositionById(
+                    nodeInOrder.node.id,
+                );
                 this.stepNodes.push(nodeInOrder);
             }
         }
         this.workgroup = data.workgroup;
         this.period = data.period;
+        this.group = data.group;
     }
-
-    ngOnInit() {}
 
     sendToNode(node: any) {
         if (this.workgroup != null) {
@@ -38,8 +46,10 @@ export class GoToNodeSelectComponent implements OnInit {
                 this.workgroup.id,
                 node.id,
             );
-        } else {
+        } else if (this.period != null) {
             this.websocketService.sendPeriodToNode(this.period.id, node.id);
+        } else {
+            this.websocketService.sendGroupToNode(this.group, node.id);
         }
     }
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/edit-group-dialog/edit-group-dialog.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/edit-group-dialog/edit-group-dialog.component.html
@@ -1,6 +1,7 @@
 <span fxLayout="row">
   <h1 mat-dialog-title i18n>Edit Group</h1>
   <span fxFlex></span>
+  <move-group-to-node [group]="group"></move-group-to-node>
   <delete-group [group]="group" [members]="membersInGroup"></delete-group>
 </span>
 <div mat-dialog-content class="info-block" cdkFocusRegionStart>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-to-node/move-group-to-node.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-to-node/move-group-to-node.component.html
@@ -1,0 +1,6 @@
+<button mat-button
+    (click)="chooseNodeToSend()"
+    matTooltip="Send group to step"
+    i18n-matTooltip>
+  <mat-icon>timeline</mat-icon>
+</button>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-to-node/move-group-to-node.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-to-node/move-group-to-node.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MoveGroupToNodeComponent } from './move-group-to-node.component';
+
+describe('MoveGroupToNodeComponent', () => {
+  let component: MoveGroupToNodeComponent;
+  let fixture: ComponentFixture<MoveGroupToNodeComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ MoveGroupToNodeComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MoveGroupToNodeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-to-node/move-group-to-node.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-to-node/move-group-to-node.component.ts
@@ -1,0 +1,25 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { Tag } from '../../../../../../app/domain/tag';
+import { GoToNodeSelectComponent } from '../../../../../score/teachingassistant/src/app/core/components/go-to-node-select/go-to-node-select.component';
+import { ConfigService } from '../../../../services/configService';
+
+@Component({
+  selector: 'move-group-to-node',
+  templateUrl: './move-group-to-node.component.html',
+  styleUrls: ['./move-group-to-node.component.scss']
+})
+export class MoveGroupToNodeComponent {
+  @Input() group: Tag;
+
+  constructor(private configService: ConfigService, private dialog: MatDialog) {}
+
+  chooseNodeToSend() {
+    this.dialog.open(GoToNodeSelectComponent, {
+      minWidth: '600px',
+      maxHeight: '800px',
+      data: { group: this.group, runId: this.configService.getRunId() },
+      panelClass: 'mat-dialog--md'
+    });
+  }
+}

--- a/src/assets/wise5/classroomMonitor/studentProgress/studentProgressController.ts
+++ b/src/assets/wise5/classroomMonitor/studentProgress/studentProgressController.ts
@@ -214,23 +214,7 @@ class StudentProgressController {
       clickOutsideToClose: true,
       escapeToClose: true
     });
-
-    // this.dialog.open(GoToNodeSelectComponent, {
-    //     minWidth: '600px',
-    //     maxHeight: '800px',
-    //     data: { workgroup: workgroup, run: this.run },
-    //     panelClass: 'mat-dialog--md',
-    // });
   }
-
-  // chooseNodeToSendPeriod(period: Period) {
-  //     this.dialog.open(GoToNodeSelectComponent, {
-  //         minWidth: '600px',
-  //         maxHeight: '800px',
-  //         data: { period: period, run: this.run },
-  //         panelClass: 'mat-dialog--md',
-  //     });
-  // }
 }
 
 export default StudentProgressController;

--- a/src/assets/wise5/services/teacherWebSocketService.ts
+++ b/src/assets/wise5/services/teacherWebSocketService.ts
@@ -7,6 +7,7 @@ import { UpgradeModule } from '@angular/upgrade/static';
 import { NotificationService } from './notificationService';
 import { Observable, Subject } from 'rxjs';
 import { AchievementService } from './achievementService';
+import { Tag } from '../../../app/domain/tag';
 
 @Injectable()
 export class TeacherWebSocketService {
@@ -117,6 +118,14 @@ export class TeacherWebSocketService {
   sendPeriodToNode(periodId, nodeId) {
     this.stomp.send(
       `/app/api/teacher/run/${this.runId}/period-to-node/${periodId}/${nodeId}`,
+      {},
+      {}
+    );
+  }
+
+  sendGroupToNode(group: Tag, nodeId: string) {
+    this.stomp.send(
+      `/app/api/teacher/run/${this.runId}/group-to-node/${group.id}/${nodeId}`,
       {},
       {}
     );


### PR DESCRIPTION
## Changes
- Teacher can move group to step via the manage groups view
- Cleaned up code

## Test
- First checkout and pull from the "manage-groups" branch in SCORE-API, to make sure that you have the updated backend code for moving group to a step
```
SCORE-API $ git checkout manage-groups
SCORE-API $ git pull
```
- In the manage groups view, click on an existing group to edit. Icon to move the group should appear at the top right
- Can move group to a step- all the members in the group who are logged in will be moved to the step
- Can change membership (add/delete members), and move the group to step. This should only move the updated members in the group to the step.
 
closes #4