### PR TITLE
Move students between groups manually and randomly

### DIFF
--- a/src/app/teacher/manage-groups.module.ts
+++ b/src/app/teacher/manage-groups.module.ts
@@ -8,6 +8,9 @@ import { EditGroupNameComponent } from '../../assets/wise5/classroomMonitor/clas
 import { ListGroupsComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/list-groups/list-groups.component';
 import { ManageGroupComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/manage-group/manage-group.component';
 import { ManageGroupsComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/manage-groups/manage-groups.component';
+import { MoveGroupMembersButtonComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-members-button/move-group-members-button.component';
+import { MoveGroupMembersDialogComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-members-dialog/move-group-members-dialog.component';
+import { MoveGroupMembersComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-members/move-group-members.component';
 import { MoveGroupToNodeComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-to-node/move-group-to-node.component';
 import { AngularJSModule } from '../common-hybrid-angular.module';
 
@@ -22,6 +25,9 @@ import { AngularJSModule } from '../common-hybrid-angular.module';
     ListGroupsComponent,
     ManageGroupComponent,
     ManageGroupsComponent,
+    MoveGroupMembersComponent,
+    MoveGroupMembersButtonComponent,
+    MoveGroupMembersDialogComponent,
     MoveGroupToNodeComponent
   ],
   imports: [AngularJSModule]

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/manage-groups/manage-groups.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/manage-groups/manage-groups.component.html
@@ -1,5 +1,8 @@
 <div class="view-content view-content--with-sidemenu">
-  <create-group></create-group>
+  <div fxFlexLayout="row wrap" fxLayoutAlign="start center" fxLayoutGap="8px">
+    <create-group></create-group>
+    <move-group-members-button></move-group-members-button>
+  </div>
   <list-groups></list-groups>
 </div>
 

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-members-button/move-group-members-button.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-members-button/move-group-members-button.component.html
@@ -1,0 +1,8 @@
+<button mat-raised-button
+    color="primary"
+    (click)="openMoveGroupMembersDialog()"
+    matTooltip="Move users between groups"
+    matTooltipPosition="above"
+    i18n-matTooltip>
+  <mat-icon>sync_alt</mat-icon>
+</button>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-members-button/move-group-members-button.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-members-button/move-group-members-button.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MoveGroupMembersButtonComponent } from './move-group-members-button.component';
+
+describe('MoveGroupMembersButtonComponent', () => {
+  let component: MoveGroupMembersButtonComponent;
+  let fixture: ComponentFixture<MoveGroupMembersButtonComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ MoveGroupMembersButtonComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MoveGroupMembersButtonComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-members-button/move-group-members-button.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-members-button/move-group-members-button.component.ts
@@ -1,0 +1,20 @@
+import { Component, OnInit } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { MoveGroupMembersDialogComponent } from '../move-group-members-dialog/move-group-members-dialog.component';
+
+@Component({
+  selector: 'move-group-members-button',
+  templateUrl: './move-group-members-button.component.html',
+  styleUrls: ['./move-group-members-button.component.scss']
+})
+export class MoveGroupMembersButtonComponent implements OnInit {
+  constructor(private dialog: MatDialog) {}
+
+  ngOnInit(): void {}
+
+  openMoveGroupMembersDialog() {
+    this.dialog.open(MoveGroupMembersDialogComponent, {
+      panelClass: 'mat-dialog--md'
+    });
+  }
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-members-dialog/AddRemoveTag.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-members-dialog/AddRemoveTag.ts
@@ -1,0 +1,31 @@
+import { Tag } from '../../../../../../app/domain/tag';
+
+export class AddRemoveTag {
+  tag: Tag;
+  workgroupIdsToAdd: number[];
+  workgroupIdsToRemove: number[];
+
+  constructor(group: any) {
+    this.tag = group;
+    this.workgroupIdsToAdd = this.getWorkgroupIdsToAdd(group);
+    this.workgroupIdsToRemove = this.getWorkgroupIdsToRemove(group);
+  }
+
+  hasAnyChanges(): boolean {
+    return this.workgroupIdsToAdd.length + this.workgroupIdsToRemove.length > 0;
+  }
+
+  private getWorkgroupIdsToAdd(group: any): number[] {
+    const teamsToAdd = this.subtract(group.membersInGroup, group.membersInGroupOriginal);
+    return teamsToAdd.map((team) => team.workgroupId);
+  }
+
+  private getWorkgroupIdsToRemove(group: any): number[] {
+    const teamsToRemove = this.subtract(group.membersInGroupOriginal, group.membersInGroup);
+    return teamsToRemove.map((team) => team.workgroupId);
+  }
+
+  private subtract(setA: any[], setB: any[]): any[] {
+    return setA.filter((element) => !setB.includes(element));
+  }
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-members-dialog/move-group-members-dialog.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-members-dialog/move-group-members-dialog.component.html
@@ -1,0 +1,32 @@
+<h1 mat-dialog-title i18n>Move students between groups</h1>
+<div mat-dialog-content class="info-block">
+  <h3 i18n>1. Choose one or more groups</h3>
+  <div fxLayout="row wrap" fxLayoutAlign="start start" fxLayoutGap="20px">
+    <span *ngFor="let group of groups">
+      <mat-checkbox [(ngModel)]="group.isSelected" (change)="selectGroup()">{{group.name}} ({{group?.membersInGroup?.length}})</mat-checkbox>
+    </span>
+  </div>
+  <mat-divider></mat-divider>
+  <h3 i18n>2. Move students manually with drag&drop or randomly using the shuffle button</h3>
+  <div fxLayout="row wrap" fxLayoutGap="8px" cdkDropListGroup>
+    <span *ngFor="let group of selectedGroups" class="group">
+      <move-group-members [group]="group" (dropped)="drop($event)" (removed)="memberRemoved()"></move-group-members>
+    </span>
+    <move-group-members *ngIf="selectedGroups.length > 0" [group]="unassignedGroup" (updated)="drop($event)"></move-group-members>
+  </div>
+</div>
+<div mat-dialog-actions fxLayoutAlign="end" fxLayoutGap="8px">
+  <button mat-button [disabled]="isProcessing || selectedGroups.length == 0"
+      matTooltip="Randomly shuffle students between selected groups"
+      i18n-matTooltip
+      (click)="shuffleBetweenSelectedGroups()">
+    <mat-icon>shuffle</mat-icon>
+    <span i18n>Shuffle</span>
+  </button>
+  <span fxFlex></span>
+  <button mat-button mat-dialog-close [disabled]="isProcessing" i18n>Cancel</button>
+  <button mat-flat-button color="primary" (click)="saveChanges()" [disabled]="isProcessing || !isDirty">
+    <mat-progress-bar *ngIf="isProcessing" mode="indeterminate"></mat-progress-bar>
+    <ng-container i18n>Save</ng-container>
+  </button>
+</div>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-members-dialog/move-group-members-dialog.component.scss
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-members-dialog/move-group-members-dialog.component.scss
@@ -1,0 +1,3 @@
+.group {
+  max-width: 200px;
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-members-dialog/move-group-members-dialog.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-members-dialog/move-group-members-dialog.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MoveGroupMembersDialogComponent } from './move-group-members-dialog.component';
+
+describe('MoveGroupMembersDialogComponent', () => {
+  let component: MoveGroupMembersDialogComponent;
+  let fixture: ComponentFixture<MoveGroupMembersDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ MoveGroupMembersDialogComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MoveGroupMembersDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-members-dialog/move-group-members-dialog.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-members-dialog/move-group-members-dialog.component.ts
@@ -1,0 +1,195 @@
+import { Component, OnInit } from '@angular/core';
+import { CdkDragDrop, transferArrayItem } from '@angular/cdk/drag-drop';
+import { MatDialog } from '@angular/material/dialog';
+import { ConfigService } from '../../../../services/configService';
+import { TagService } from '../../../../services/tagService';
+import { TeacherDataService } from '../../../../services/teacherDataService';
+import { AddRemoveTag } from './AddRemoveTag';
+
+@Component({
+  selector: 'move-group-members-dialog',
+  templateUrl: './move-group-members-dialog.component.html',
+  styleUrls: ['./move-group-members-dialog.component.scss']
+})
+export class MoveGroupMembersDialogComponent implements OnInit {
+  isDirty: boolean;
+  isProcessing: boolean;
+  groups: any[] = [];
+  unassignedGroup: any = { name: 'Unassigned', membersInGroup: [] };
+  selectedGroups = [];
+
+  constructor(
+    private configService: ConfigService,
+    private dialog: MatDialog,
+    protected tagService: TagService,
+    protected teacherDataService: TeacherDataService
+  ) {}
+
+  ngOnInit(): void {
+    this.tagService.retrieveRunTags().subscribe(() => {
+      this.groups = Object.assign(this.groups, this.tagService.tags);
+      this.groups.map((group) => this.initWorkgroups(group));
+    });
+  }
+
+  initWorkgroups(group: any): void {
+    this.tagService.retrieveWorkgroupsWithTag(group).subscribe((workgroups: any[]) => {
+      group.workgroups = workgroups.filter((workgroup) => this.filterCurrentPeriod(workgroup));
+      this.initializeMembers(group);
+    });
+  }
+
+  initializeMembers(group: any): void {
+    group.membersNotInGroup = this.getSortedWorkgroupsInPeriod();
+    group.membersInGroup = [];
+    group.workgroups.forEach((memberInGroup) => {
+      this.moveMembersBetweenGroups(group, memberInGroup);
+    });
+    group.membersInGroupOriginal = Array.from(group.membersInGroup);
+  }
+
+  protected getSortedWorkgroupsInPeriod(): any[] {
+    return this.getSortedWorkgroupsInRun()
+      .map((workgroup) => this.setDisplayNames(workgroup))
+      .filter((workgroup) => this.filterCurrentPeriod(workgroup));
+  }
+
+  private getSortedWorkgroupsInRun(): any[] {
+    return this.configService.getClassmateUserInfos().sort((a, b) => {
+      return a.workgroupId - b.workgroupId;
+    });
+  }
+
+  private setDisplayNames(workgroup: any): any {
+    workgroup.displayNames = this.configService.getDisplayUsernamesByWorkgroupId(
+      workgroup.workgroupId
+    );
+    return workgroup;
+  }
+
+  private filterCurrentPeriod(workgroup: any): boolean {
+    return workgroup.periodId === this.teacherDataService.getCurrentPeriodId();
+  }
+
+  private moveMembersBetweenGroups(group, memberInGroup: any): void {
+    group.membersNotInGroup.forEach((memberNotInGroup) => {
+      if (memberNotInGroup.workgroupId === memberInGroup.id) {
+        group.membersInGroup.push(memberNotInGroup);
+      }
+    });
+  }
+
+  selectGroup(): void {
+    this.selectedGroups = this.groups.filter((group) => group.isSelected);
+    this.updateUnassignedGroup();
+  }
+
+  private updateUnassignedGroup(): void {
+    this.unassignedGroup.membersInGroup = this.getAllUnassignedMembersInSelectedGroups();
+  }
+
+  private getAllUnassignedMembersInSelectedGroups(): any[] {
+    const unassignedMembers = [];
+    const membersInSelectedGroups = this.getAllMembersInSelectedGroups();
+    this.selectedGroups.forEach((group) => {
+      group.membersNotInGroup.forEach((memberNotInGroup) => {
+        if (
+          !membersInSelectedGroups.some((member) => {
+            return member.workgroupId === memberNotInGroup.workgroupId;
+          })
+        ) {
+          unassignedMembers.push(memberNotInGroup);
+        }
+      });
+    });
+    return this.removeDuplicates(unassignedMembers);
+  }
+
+  shuffleBetweenSelectedGroups(): void {
+    const allMembersInSelectedGroups = this.removeDuplicates(
+      this.getAllMembersInSelectedGroups().concat(this.unassignedGroup.membersInGroup)
+    );
+    this.clearMembersInSelectedGroups();
+    this.clearUnassignedGroupMembers();
+    const allMembersInSelectedGroupsShuffled = this.shuffleArray(allMembersInSelectedGroups);
+    allMembersInSelectedGroupsShuffled.forEach((memberInSelectedGroups, i) => {
+      this.selectedGroups[i % this.selectedGroups.length].membersInGroup.push(
+        memberInSelectedGroups
+      );
+    });
+    this.isDirty = true;
+  }
+
+  private getAllMembersInSelectedGroups(): any[] {
+    const membersInSelectedGroups = [];
+    this.selectedGroups.forEach((group) =>
+      group.membersInGroup.forEach((memberInGroup) => membersInSelectedGroups.push(memberInGroup))
+    );
+    return membersInSelectedGroups;
+  }
+
+  private removeDuplicates(groups: any[]): any[] {
+    const uniqueGroups = new Set();
+    groups.forEach((group) => uniqueGroups.add(group));
+    return Array.from(uniqueGroups);
+  }
+
+  private clearMembersInSelectedGroups(): void {
+    this.selectedGroups.forEach((group) => {
+      group.membersInGroup = [];
+    });
+  }
+
+  private clearUnassignedGroupMembers(): void {
+    this.unassignedGroup.membersInGroup = [];
+  }
+
+  // https://stackoverflow.com/a/2450976/4970939
+  // Uses Fisher-Yates shuffle https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
+  private shuffleArray(array: any[]): any[] {
+    let currentIndex = array.length,
+      randomIndex;
+    while (currentIndex != 0) {
+      randomIndex = Math.floor(Math.random() * currentIndex);
+      currentIndex--;
+      [array[currentIndex], array[randomIndex]] = [array[randomIndex], array[currentIndex]];
+    }
+    return array;
+  }
+
+  saveChanges(): void {
+    this.isProcessing = true;
+    const addRemoveTags = this.groups.map((group) => new AddRemoveTag(group));
+    this.tagService.addRemoveTagsFromWorkgroups(addRemoveTags).subscribe(() => {
+      this.emitTagChanges(addRemoveTags);
+      this.isProcessing = false;
+      this.dialog.closeAll();
+    });
+  }
+
+  private emitTagChanges(addRemoveTags: AddRemoveTag[]): void {
+    addRemoveTags.forEach((addRemoveTag) => {
+      if (addRemoveTag.hasAnyChanges()) {
+        this.tagService.emitTagChanged(addRemoveTag.tag);
+      }
+    });
+  }
+
+  drop(event: CdkDragDrop<string[]>): void {
+    if (event.previousContainer !== event.container) {
+      transferArrayItem(
+        event.previousContainer.data,
+        event.container.data,
+        event.previousIndex,
+        event.currentIndex
+      );
+      this.isDirty = true;
+      this.updateUnassignedGroup();
+    }
+  }
+
+  memberRemoved(): void {
+    this.isDirty = true;
+    this.updateUnassignedGroup();
+  }
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-members/move-group-members.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-members/move-group-members.component.html
@@ -1,0 +1,35 @@
+<h3 fxLayout="row" fxLayoutAlign="start center">
+  <span>{{group.name}} ({{group.membersInGroup.length}})</span>
+  <span fxFlex></span>
+  <button mat-icon-button
+      *ngIf="group.name != 'Unassigned'"
+      (click)="removeAllMembersFromGroup()"
+      matTooltip="Remove all students from group"
+      matTooltipPosition="above"
+      i18n-matTooltip>
+    <mat-icon>clear_all</mat-icon>
+  </button>
+</h3>
+<div class="members"
+    cdkDropList
+    [cdkDropListData]="group.membersInGroup"
+    [cdkDropListEnterPredicate]="canDrop"
+    (cdkDropListDropped)="dropped.next($event)">
+  <div class="member"
+      *ngFor="let member of group.membersInGroup; let i = index"
+      cdkDrag
+      [cdkDragData]="member"
+      fxLayout="row"
+      fxLayoutAlign="start center">
+    <span>{{member.username}}</span>
+    <span fxFlex></span>
+    <button mat-icon-button
+        *ngIf="group.name != 'Unassigned'"
+        (click)="removeFromGroup(i)"
+        matTooltip="Remove student from group"
+        matTooltipPosition="above"
+        i18n-matTooltip>
+      <mat-icon>clear</mat-icon>
+    </button>
+  </div>
+</div>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-members/move-group-members.component.scss
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-members/move-group-members.component.scss
@@ -1,0 +1,26 @@
+.members {
+  border: 1px solid black;
+  min-height: 50px;
+  min-width: 150px;
+}
+
+.member {
+  border: 1px solid gray;
+  padding: 2px 4px;
+  margin: 4px;
+}
+
+.member:hover {
+  cursor: move;
+}
+
+h3 {
+  margin-bottom: 2px;
+}
+
+.mat-icon-button {
+  height: 24px !important;
+  width: 24px !important;
+  font-size: 24px !important;
+  line-height: 24px;
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-members/move-group-members.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-members/move-group-members.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MoveGroupMembersComponent } from './move-group-members.component';
+
+describe('MoveGroupMembersComponent', () => {
+  let component: MoveGroupMembersComponent;
+  let fixture: ComponentFixture<MoveGroupMembersComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ MoveGroupMembersComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MoveGroupMembersComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-members/move-group-members.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/move-group-members/move-group-members.component.ts
@@ -1,0 +1,31 @@
+import { CdkDrag, CdkDropList } from '@angular/cdk/drag-drop';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+
+@Component({
+  selector: 'move-group-members',
+  templateUrl: './move-group-members.component.html',
+  styleUrls: ['./move-group-members.component.scss']
+})
+export class MoveGroupMembersComponent implements OnInit {
+  @Input() group: any;
+  @Output() dropped = new EventEmitter();
+  @Output() removed = new EventEmitter();
+
+  constructor() {}
+
+  ngOnInit(): void {}
+
+  canDrop(drag: CdkDrag, drop: CdkDropList): boolean {
+    return !drop.data.some((workgroup) => workgroup.workgroupId === drag.data.workgroupId);
+  }
+
+  removeFromGroup(index: number) {
+    this.group.membersInGroup.splice(index, 1);
+    this.removed.next();
+  }
+
+  removeAllMembersFromGroup(): void {
+    this.group.membersInGroup = [];
+    this.removed.next();
+  }
+}

--- a/src/assets/wise5/services/tagService.ts
+++ b/src/assets/wise5/services/tagService.ts
@@ -94,6 +94,24 @@ export class TagService {
     });
   }
 
+  removeTagFromWorkgroups(workgroupIds: number[], tag: Tag) {
+    return this.http.request('DELETE', `/api/tag/${tag.id}/workgroups/delete`, {
+      headers: new HttpHeaders({
+        'Content-Type': 'application/json'
+      }),
+      body: workgroupIds
+    });
+  }
+
+  addRemoveTagsFromWorkgroups(addRemoveTagsParam: any) {
+    return this.http.request('POST', `/api/tag/workgroups/add-delete`, {
+      headers: new HttpHeaders({
+        'Content-Type': 'application/json'
+      }),
+      body: addRemoveTagsParam
+    });
+  }
+
   getNextAvailableTag() {
     this.getTagsFromProject();
     let counter = 1;


### PR DESCRIPTION
## Changes
- Add Move Students Between Groups dialog
- In the new Move Students Between Groups dialog, added the following features:
  - show existing groups and allow teacher to choose one or more groups
  - move students between groups manually via drag and drop
  - move students between groups randomly via the shuffle button
  - remove one student from group using the "x" next to the student
  - clear all students from group using the clear all button next to the group name
  - cancel closes the dialog, and does not save changes
  - save saves all changes and closes the dialog

## Test
- First checkout and pull from the "manage-groups" branch in SCORE-API, to make sure that you have the updated backend code for deleting and retrieving groups
```
SCORE-API $ git checkout manage-groups
SCORE-API $ git pull
```
- Verify that you can do all of the above grouping actions as a teacher 

Closes #6