### PR TITLE
style(manage group): add "unassigned" column in group edit

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/create-group-dialog/create-group-dialog.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/create-group-dialog/create-group-dialog.component.html
@@ -2,6 +2,7 @@
 <div mat-dialog-content class="info-block">
   <h3 i18n>Enter a new group name</h3>
   <edit-group-name [groupNameForm]="groupNameForm"></edit-group-name>
+  <mat-divider></mat-divider>
   <h3 i18n>Select students to add to your new group (optional):</h3>
   <edit-group-members
       [membersInGroup]="membersInGroup"
@@ -10,7 +11,6 @@
       (deleteMemberEvent)="deleteMember($event)"></edit-group-members>
   <p class="info mat-small" i18n>*Note: You can always add or remove students to this group by editing the group.</p>
 </div>
-<mat-divider></mat-divider>
 <div mat-dialog-actions fxLayoutAlign="end" fxLayoutGap="8px">
   <button mat-button mat-dialog-close [disabled]="isProcessing" i18n>Cancel</button>
   <button mat-flat-button

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/edit-group-dialog/edit-group-dialog.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/edit-group-dialog/edit-group-dialog.component.html
@@ -6,6 +6,7 @@
 <div mat-dialog-content class="info-block" cdkFocusRegionStart>
   <h3 i18n>Group name</h3>
   <edit-group-name [groupNameForm]="groupNameForm"></edit-group-name>
+  <mat-divider></mat-divider>
   <h3 i18n>Group membership</h3>
   <edit-group-members
       [membersInGroup]="membersInGroup"
@@ -13,7 +14,6 @@
       (addMemberEvent)="addMember($event)"
       (deleteMemberEvent)="deleteMember($event)"></edit-group-members>
 </div>
-<mat-divider></mat-divider>
 <div mat-dialog-actions fxLayoutAlign="start center" fxLayoutGap="8px" style="padding: 0">
   <mat-progress-spinner [diameter]="24" *ngIf="isProcessing" mode="indeterminate"></mat-progress-spinner>
   <span *ngIf="isShowSavedMessage" class="isSavedMessage" i18n>All changes saved.</span>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/edit-group-members/edit-group-members.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/edit-group-members/edit-group-members.component.html
@@ -1,19 +1,23 @@
-<div fxLayout="column" fxLayout.gt-sm="row">
-  <div class="initial-members notice-bg-bg" fxFlex="100" fxFlex.gt-sm="33">
-    <div *ngIf="membersInGroup.size == 0" class="mat-small" i18n>No students added</div>
-    <div class="member-list" *ngIf="membersInGroup.size > 0">
-      <div class="member-list-item" *ngFor="let member of membersInGroup; let i=index;"
-          fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="8px">
-        <mat-icon class="secondary-text">account_circle</mat-icon>
-        <span class="mat-small">{{member.username}}</span>
-        <span fxFlex></span>
-        <button mat-icon-button (click)="deleteMemberEvent.next(member)" i18n-aria-label aria-label="Delete member">
-          <mat-icon class="secondary-text">close</mat-icon>
-        </button>
+<div fxLayout="column" fxLayout.gt-sm="row" fxLayoutGap="8px">
+  <div fxFlex="100" fxFlex.gt-sm="33">
+    <h4 i18n>Current members</h4>
+    <div class="initial-members notice-bg-bg">
+      <div *ngIf="membersInGroup.size == 0" class="mat-small" i18n>No students added</div>
+      <div class="member-list" *ngIf="membersInGroup.size > 0">
+        <div class="member-list-item" *ngFor="let member of membersInGroup; let i=index;"
+            fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="8px">
+          <mat-icon class="secondary-text">account_circle</mat-icon>
+          <span class="mat-small">{{member.username}}</span>
+          <span fxFlex></span>
+          <button mat-icon-button (click)="deleteMemberEvent.next(member)" i18n-aria-label aria-label="Delete member">
+            <mat-icon class="secondary-text">close</mat-icon>
+          </button>
+        </div>
       </div>
     </div>
   </div>
   <div fxFlex="100" fxFlex.gt-sm="67">
+    <h4 i18n>Unassigned</h4>
     <div fxLayout="row wrap" fxLayoutAlign="start start">
       <div class="member" *ngFor="let member of membersNotInGroup" >
         <button mat-stroked-button (click)="addMemberEvent.next(member)">

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/edit-group-members/edit-group-members.component.scss
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manage-groups/edit-group-members/edit-group-members.component.scss
@@ -1,0 +1,7 @@
+.initial-members {
+  min-height: 100px;
+}
+
+h4 {
+  margin-bottom: 8px;
+}


### PR DESCRIPTION
## Changes
- Add "unassigned" column in group edit view. This also affects create group view.
- Clean up the create/edit group dialog ui using fxLayoutGap and mat-divider.

## Test
- Create and Edit group dialog ui improvements look ok

Closes #8